### PR TITLE
Fix PDF export crash

### DIFF
--- a/takeofftool/viewer.py
+++ b/takeofftool/viewer.py
@@ -33,6 +33,10 @@ class HighlightItem(QtWidgets.QGraphicsObject):
         self._rect = rect
         self.update()
 
+    def rect(self) -> QtCore.QRectF:
+        """Return the item's rectangle."""
+        return self._rect
+
     # context menu ----------------------------------------------------------
     def contextMenuEvent(self, event: QtWidgets.QGraphicsSceneContextMenuEvent):
         menu = QtWidgets.QMenu()


### PR DESCRIPTION
## Summary
- add missing `rect()` method for `HighlightItem`

## Testing
- `python -m py_compile takeofftool/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68473a3ef0a48326bf10f3292a6bcdfa