### PR TITLE
Add Fire Alarm + Low Voltage tabs & UI tweaks

### DIFF
--- a/takeofftool/main_window.py
+++ b/takeofftool/main_window.py
@@ -43,8 +43,10 @@ class MainWindow(QtWidgets.QMainWindow):
         sl = QtWidgets.QHBoxLayout(sf)
         self.sum_hours = QtWidgets.QLabel("Total Hours: 0.00")
         self.sum_devices = QtWidgets.QLabel("Total Devices: 0")
+        self.sum_points = QtWidgets.QLabel("Total Points: 0")
         sl.addWidget(self.sum_hours)
         sl.addWidget(self.sum_devices)
+        sl.addWidget(self.sum_points)
         rlay.addWidget(sf)
 
         self.category_tabs = QtWidgets.QTabWidget()
@@ -57,9 +59,15 @@ class MainWindow(QtWidgets.QMainWindow):
         splitter.setSizes([120, 900, 180])
 
         self.panels: dict[str, TakeoffPanel] = {}
-        for name in ["General", "Lighting", "Mechanical", "Demo"]:
-            use_wire = name != "Demo"
-            p = TakeoffPanel(include_wire=use_wire)
+        for name in [
+            "General",
+            "Lighting",
+            "Mechanical",
+            "Fire Alarm",
+            "Low Voltage",
+            "Demo",
+        ]:
+            p = TakeoffPanel(include_wire=False)
             p.setPdfView(self.pdf_view)
             self.category_tabs.addTab(p, name)
             self.panels[name] = p
@@ -97,7 +105,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.pdf_view.setDrawingMode(True)
 
     def update_summary(self):
-        total_hours, total_devices = 0.0, 0
+        total_hours, total_devices, total_points = 0.0, 0, 0
         for name, panel in self.panels.items():
             for it in panel.takeoff_items:
                 cnt = len([h for h in it["highlights"] if h.scene()])
@@ -108,8 +116,10 @@ class MainWindow(QtWidgets.QMainWindow):
                 total_hours += cnt * lab
                 if name != "Demo":
                     total_devices += cnt
+                total_points += cnt
         self.sum_hours.setText(f"Total Hours: {total_hours:.2f}")
         self.sum_devices.setText(f"Total Devices: {total_devices}")
+        self.sum_points.setText(f"Total Points: {total_points}")
 
     # Thumbnail handling -------------------------------------------------
     def populateThumbnails(self):

--- a/takeofftool/panels.py
+++ b/takeofftool/panels.py
@@ -26,7 +26,7 @@ class TakeoffPanel(QtWidgets.QWidget):
     importRequested = QtCore.pyqtSignal()
     totalsUpdated = QtCore.pyqtSignal()
 
-    def __init__(self, parent=None, *, include_wire: bool = True):
+    def __init__(self, parent=None, *, include_wire: bool = False):
         super().__init__(parent)
         self.include_wire = include_wire
 
@@ -81,6 +81,7 @@ class TakeoffPanel(QtWidgets.QWidget):
         count_lbl = QtWidgets.QLabel("Count: 0")
         name_f = QtWidgets.QLineEdit()
         name_f.setPlaceholderText("Name")
+        name_f.setMinimumWidth(200)
         labor_lbl = QtWidgets.QLabel("Labor:")
         labor_f = QtWidgets.QLineEdit()
         labor_f.setPlaceholderText("0.0")

--- a/takeofftool/viewer.py
+++ b/takeofftool/viewer.py
@@ -130,7 +130,7 @@ class PDFGraphicsView(QtWidgets.QGraphicsView):
         if hasattr(self, "_pixmap_item") and self._pixmap_item:
             self._scene.removeItem(self._pixmap_item)  # type: ignore[attr-defined]
         page = self.doc.load_page(page_num)
-        pix = page.get_pixmap()
+        pix = page.get_pixmap(matrix=fitz.Matrix(2, 2))
         img = QtGui.QImage(
             pix.samples, pix.width, pix.height, pix.stride, QtGui.QImage.Format_RGB888
         )


### PR DESCRIPTION
## Summary
- add Fire Alarm and Low Voltage tabs
- hide wire fields on all tabs
- enlarge the takeoff name text box
- show Total Points in the summary header
- bump PDF view render resolution

## Testing
- `python -m compileall -q takeofftool`
- `python -m pip install -r requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68543b805dd88326b455612b4c649bd2